### PR TITLE
Update Form.tsx to use Dimensions.get('window').width for iPad

### DIFF
--- a/src/components/ui/Form.tsx
+++ b/src/components/ui/Form.tsx
@@ -7,6 +7,7 @@ import * as WebBrowser from "expo-web-browser";
 import React from "react";
 import {
   Button,
+  Dimensions,
   GestureResponderEvent,
   OpaqueColorValue,
   RefreshControl,
@@ -140,7 +141,7 @@ function InnerList({ contentContainerStyle, ...props }: ListProps) {
             contentContainerStyle
           )}
           style={{
-            maxWidth: 768,
+            maxWidth: Dimensions.get('window').width,
             width: process.env.EXPO_OS === "web" ? "100%" : undefined,
             marginHorizontal:
               process.env.EXPO_OS === "web" ? "auto" : undefined,


### PR DESCRIPTION
If you don't use Dimensions the form is off centered and leaves empty space on iPad