### PR TITLE
fix: pass custom Stack.Screen props to React.isValidElement

### DIFF
--- a/src/components/ui/Stack.tsx
+++ b/src/components/ui/Stack.tsx
@@ -37,7 +37,7 @@ export default function Stack({
   ...props
 }: React.ComponentProps<typeof NativeStack>) {
   const processedChildren = React.Children.map(children, (child) => {
-    if (React.isValidElement(child)) {
+    if (React.isValidElement<StackScreenProps>(child)) {
       const { sheet, modal, ...props } = child.props;
       if (sheet) {
         return React.cloneElement(child, {
@@ -72,11 +72,11 @@ export default function Stack({
   );
 }
 
-Stack.Screen = NativeStack.Screen as React.FC<
-  React.ComponentProps<typeof NativeStack.Screen> & {
-    /** Make the sheet open as a bottom sheet with default options on iOS. */
-    sheet?: boolean;
-    /** Make the screen open as a modal. */
-    modal?: boolean;
-  }
->;
+type StackScreenProps = React.ComponentProps<typeof NativeStack.Screen> & {
+  /** Make the sheet open as a bottom sheet with default options on iOS. */
+  sheet?: boolean;
+  /** Make the screen open as a modal. */
+  modal?: boolean;
+};
+
+Stack.Screen = NativeStack.Screen as StackScreenProps;


### PR DESCRIPTION
fixes type errors caused by `React.isValidElement` having `unknown` type within

### Without the types:
<img width="984" alt="Screenshot 2025-06-07 at 22 00 10" src="https://github.com/user-attachments/assets/7e1b7290-808e-47b9-8502-5ec1cbedf7fc" />

### With StackScreenProps types passed:
<img width="1042" alt="Screenshot 2025-06-07 at 22 01 14" src="https://github.com/user-attachments/assets/924caa2a-d572-4df4-a00a-4e61d0aaca96" />
