### PR TITLE
Add Konsta UI-based liquid glass header for web

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "expo-system-ui": "~55.0.1",
         "expo-updates": "~55.0.3",
         "expo-web-browser": "~55.0.1",
+        "konsta": "^5.0.6",
         "lucide-react": "^0.562.0",
         "nativewind": "5.0.0-preview.2",
         "prism-react-renderer": "^2.4.1",
@@ -1611,6 +1612,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "konsta": ["konsta@5.0.6", "", { "dependencies": { "tailwind-merge": "^3.3.1" } }, "sha512-qMwBigssLnqTHDfpFnLPMYYWP329FGI6jr+qMpzVXIRsvHUwRmE9y9jxKf8IURh1n4aCAaytD/04BS6yNoKd3w=="],
 
     "lan-network": ["lan-network@0.1.7", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ=="],
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "expo-system-ui": "~55.0.1",
     "expo-updates": "~55.0.3",
     "expo-web-browser": "~55.0.1",
+    "konsta": "^5.0.6",
     "lucide-react": "^0.562.0",
     "nativewind": "5.0.0-preview.2",
     "prism-react-renderer": "^2.4.1",

--- a/src/components/layout/konsta-stack-header.web.tsx
+++ b/src/components/layout/konsta-stack-header.web.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "expo-router";
+import { KonstaProvider, Navbar, NavbarBackLink } from "konsta/react";
+import { cn } from "@/lib/utils";
+import { SFIcon } from "@/components/ui/sf-icon";
+import {
+  useStackHeaderContext,
+  useCanGoBack,
+} from "@/components/layout/stack-context.web";
+
+/* ----------------------------------------------------------------------------------
+ * Konsta UI Web Stack Header
+ * ----------------------------------------------------------------------------------
+ *
+ * A liquid glass-style header using Konsta UI's Navbar component.
+ * Designed to match iOS 26+ Liquid Glass appearance on the web.
+ */
+
+interface KonstaStackHeaderProps {
+  /** Whether to use the floating pill style (true) or full-width bar (false) */
+  floatingStyle?: boolean;
+}
+
+export function KonstaStackHeader({ floatingStyle = true }: KonstaStackHeaderProps = {}) {
+  const router = useRouter();
+  const { isSidebarOpen, isInsideTabBar, headerConfig } = useStackHeaderContext();
+  const canGoBack = useCanGoBack();
+
+  const { title, headerLeft, headerRight, headerShown = true } = headerConfig;
+
+  if (!headerShown) {
+    return null;
+  }
+
+  // When floating bar is visible (sidebar closed in tab bar mode),
+  // hide the center title to let the floating bar be prominent
+  const showCenterTitle = !isInsideTabBar || isSidebarOpen;
+
+  const hasLeftContent = canGoBack || !!headerLeft;
+  const hasRightContent = !!headerRight;
+
+  // Don't render header if there's nothing to show
+  if (!hasLeftContent && !hasRightContent && !title) {
+    return null;
+  }
+
+  // Render floating pill-style header (iOS Liquid Glass style)
+  if (floatingStyle) {
+    return (
+      <KonstaProvider theme="ios" dark>
+        <div
+          data-slot="konsta-stack-header-wrapper"
+          className={cn(
+            "pointer-events-none fixed top-4 z-30",
+            "flex items-start justify-between gap-2",
+            "right-4",
+            isSidebarOpen ? "left-78" : "left-4"
+          )}
+        >
+          {/* Left pill - Back button or custom left content */}
+          <div
+            data-slot="konsta-header-left"
+            className={cn(
+              "pointer-events-auto",
+              "overflow-hidden rounded-full",
+              // Liquid Glass styling
+              "liquid-glass-pill",
+              "transition-all duration-300",
+              !hasLeftContent && "opacity-0 scale-95 pointer-events-none"
+            )}
+          >
+            {canGoBack && !headerLeft ? (
+              <NavbarBackLink
+                text="Back"
+                showText
+                onClick={() => router.back()}
+                className="konsta-back-link"
+              />
+            ) : (
+              headerLeft
+            )}
+          </div>
+
+          {/* Center pill - Title */}
+          <div
+            data-slot="konsta-header-center"
+            className={cn(
+              "pointer-events-auto",
+              "overflow-hidden rounded-full px-4 py-2.5",
+              // Liquid Glass styling
+              "liquid-glass-pill",
+              "transition-all duration-300 ease-out",
+              showCenterTitle && title
+                ? "opacity-100 scale-100"
+                : "opacity-0 scale-95 pointer-events-none"
+            )}
+          >
+            <span className="text-sm font-semibold text-(--sf-text) whitespace-nowrap">
+              {title}
+            </span>
+          </div>
+
+          {/* Right pill - Custom right content */}
+          <div
+            data-slot="konsta-header-right"
+            className={cn(
+              "pointer-events-auto",
+              "overflow-hidden rounded-full",
+              // Liquid Glass styling
+              "liquid-glass-pill",
+              "transition-all duration-300",
+              !hasRightContent && "opacity-0 scale-95 pointer-events-none"
+            )}
+          >
+            {headerRight}
+          </div>
+        </div>
+
+        {/* Embedded styles for liquid glass effect */}
+        <style>{`
+          .liquid-glass-pill {
+            background: color-mix(in srgb, var(--sf-grouped-bg-2) 65%, transparent);
+            backdrop-filter: blur(40px) saturate(180%);
+            -webkit-backdrop-filter: blur(40px) saturate(180%);
+            box-shadow:
+              0 0 0 0.5px color-mix(in srgb, var(--sf-border) 50%, transparent),
+              0 2px 8px -2px rgba(0, 0, 0, 0.15),
+              0 8px 24px -4px rgba(0, 0, 0, 0.12);
+          }
+
+          @media (prefers-color-scheme: dark) {
+            .liquid-glass-pill {
+              background: color-mix(in srgb, var(--sf-grouped-bg-2) 55%, transparent);
+              box-shadow:
+                0 0 0 0.5px color-mix(in srgb, var(--sf-border) 40%, transparent),
+                0 0 0 1px rgba(255, 255, 255, 0.05) inset,
+                0 2px 8px -2px rgba(0, 0, 0, 0.4),
+                0 8px 24px -4px rgba(0, 0, 0, 0.3);
+            }
+          }
+
+          .konsta-back-link {
+            display: flex !important;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.5rem 0.75rem 0.5rem 0.5rem;
+            color: var(--sf-text);
+            font-size: 0.875rem;
+            font-weight: 500;
+            transition: background-color 150ms;
+          }
+
+          .konsta-back-link:hover {
+            background-color: var(--sf-fill);
+          }
+        `}</style>
+      </KonstaProvider>
+    );
+  }
+
+  // Render full-width bar style (alternative mode)
+  return (
+    <KonstaProvider theme="ios" dark>
+      <div
+        data-slot="konsta-stack-header-bar"
+        className={cn(
+          "fixed top-0 z-30 w-full",
+          isSidebarOpen ? "left-78" : "left-0",
+          "right-0"
+        )}
+      >
+        <Navbar
+          title={showCenterTitle ? title : undefined}
+          left={
+            canGoBack && !headerLeft ? (
+              <NavbarBackLink
+                text="Back"
+                showText
+                onClick={() => router.back()}
+              />
+            ) : (
+              headerLeft
+            )
+          }
+          right={headerRight}
+          transparent={false}
+          bgClassName="liquid-glass-bar"
+          className="konsta-navbar"
+        />
+      </div>
+
+      <style>{`
+        .liquid-glass-bar {
+          background: color-mix(in srgb, var(--sf-grouped-bg-2) 65%, transparent) !important;
+          backdrop-filter: blur(40px) saturate(180%) !important;
+          -webkit-backdrop-filter: blur(40px) saturate(180%) !important;
+        }
+
+        .konsta-navbar {
+          --k-navbar-bg-color: transparent;
+          border-bottom: 0.5px solid color-mix(in srgb, var(--sf-border) 50%, transparent);
+        }
+      `}</style>
+    </KonstaProvider>
+  );
+}
+
+/* ----------------------------------------------------------------------------------
+ * Konsta Header Button
+ * ----------------------------------------------------------------------------------
+ *
+ * A button component styled to match Konsta UI's iOS appearance
+ * for use in the header's left/right areas.
+ */
+
+interface KonstaHeaderButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: string;
+  children?: React.ReactNode;
+}
+
+export function KonstaHeaderButton({
+  icon,
+  children,
+  className,
+  ...props
+}: KonstaHeaderButtonProps) {
+  return (
+    <button
+      className={cn(
+        "flex h-10 items-center gap-1.5 rounded-full px-3",
+        "text-sf-text hover:bg-sf-fill",
+        "transition-colors",
+        className
+      )}
+      {...props}
+    >
+      {icon && <SFIcon name={icon as any} className="text-sf-text text-xl" />}
+      {children && <span className="text-sm font-medium">{children}</span>}
+    </button>
+  );
+}
+
+export default KonstaStackHeader;

--- a/src/components/layout/stack-context.web.tsx
+++ b/src/components/layout/stack-context.web.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useNavigation } from "expo-router";
 
 /* ----------------------------------------------------------------------------------
  * Stack Header Context
@@ -55,4 +56,27 @@ export function useStackHeaderConfig(config: StackHeaderConfig) {
   React.useEffect(() => {
     setHeaderConfig(config);
   }, [config.headerLeft, config.headerRight, setHeaderConfig]);
+}
+
+/**
+ * Hook to reactively check if navigation can go back.
+ * Uses navigation.canGoBack() but subscribes to state changes
+ * to trigger re-renders when the navigation state changes.
+ */
+export function useCanGoBack(): boolean {
+  const navigation = useNavigation();
+
+  const getSnapshot = React.useCallback(() => {
+    return navigation.canGoBack();
+  }, [navigation]);
+
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      const unsubscribe = navigation.addListener("state", callback);
+      return unsubscribe;
+    },
+    [navigation]
+  );
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/components/layout/stack.web.tsx
+++ b/src/components/layout/stack.web.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Stack as ExpoStack, useRouter, useNavigation } from "expo-router";
+import { Stack as ExpoStack, useRouter } from "expo-router";
 import { cn } from "@/lib/utils";
 import { SFIcon } from "@/components/ui/sf-icon";
 import { useTabBarController, ProgressiveBlurBackdrop } from "@/components/ui/tab-bar-controller.web";
@@ -9,31 +9,10 @@ import {
   StackHeaderContext,
   useStackHeaderContext,
   useStackHeaderConfig,
+  useCanGoBack,
   type StackHeaderConfig,
 } from "@/components/layout/stack-context.web";
-
-/**
- * Hook to reactively check if navigation can go back.
- * Uses navigation.canGoBack() but subscribes to state changes
- * to trigger re-renders when the navigation state changes.
- */
-function useCanGoBack(): boolean {
-  const navigation = useNavigation();
-
-  const getSnapshot = React.useCallback(() => {
-    return navigation.canGoBack();
-  }, [navigation]);
-
-  const subscribe = React.useCallback(
-    (callback: () => void) => {
-      const unsubscribe = navigation.addListener("state", callback);
-      return unsubscribe;
-    },
-    [navigation]
-  );
-
-  return React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-}
+import { KonstaStackHeader, KonstaHeaderButton } from "./konsta-stack-header.web";
 
 /* Stack Header Context is imported from stack-context.web.tsx to avoid require cycles */
 
@@ -73,127 +52,10 @@ function TabBarAwareProviderFallback({ children }: { children: React.ReactNode }
 }
 
 /* ----------------------------------------------------------------------------------
- * Web Stack Header
- * ----------------------------------------------------------------------------------
- *
- * Reads navigation state and renders a floating header.
- * This is rendered alongside the Stack, not as a native header option.
- */
-
-function WebStackHeader() {
-  const router = useRouter();
-  const { isSidebarOpen, isInsideTabBar, headerConfig } = useStackHeaderContext();
-  const canGoBack = useCanGoBack();
-
-  const { title, headerLeft, headerRight, headerShown = true } = headerConfig;
-
-  if (!headerShown) {
-    return null;
-  }
-
-  // When floating bar is visible (sidebar closed in tab bar mode),
-  // hide the center title to let the floating bar be prominent
-  const showCenterTitle = !isInsideTabBar || isSidebarOpen;
-
-  const hasLeftContent = canGoBack || !!headerLeft;
-  const hasRightContent = !!headerRight;
-
-  // Don't render header if there's nothing to show
-  if (!hasLeftContent && !hasRightContent && !title) {
-    return null;
-  }
-
-  return (
-    <>
-      {/* Progressive blur backdrop for header area */}
-      <ProgressiveBlurBackdrop
-        position="top"
-        className={cn(
-          "fixed z-20",
-          isSidebarOpen ? "left-78" : "left-0"
-        )}
-      />
-
-      <header
-        data-slot="stack-floating-header"
-        data-sidebar-open={isSidebarOpen}
-        className={cn(
-          "pointer-events-none fixed top-4 z-30",
-          "flex items-start justify-between",
-          "right-4",
-          // When sidebar is open, account for its width (sidebar is ~296px + padding)
-          isSidebarOpen ? "left-78" : "left-4"
-        )}
-      >
-        {/* Left toolbar */}
-        <div
-          data-slot="stack-header-left"
-          className={cn(
-            "pointer-events-auto flex items-center",
-            "rounded-full",
-            "bg-(--sf-grouped-bg-2)/80 backdrop-blur-xl",
-            "shadow-lg shadow-black/10",
-            "transition-all duration-300",
-            !hasLeftContent && "opacity-0 scale-95 pointer-events-none"
-          )}
-        >
-        {canGoBack && !headerLeft && (
-          <button
-            onClick={() => router.back()}
-            className={cn(
-              "flex h-10 items-center gap-1 rounded-full pl-2 pr-3",
-              "text-sf-text hover:bg-sf-fill",
-              "transition-colors"
-            )}
-          >
-            <SFIcon name="chevron.left" className="text-sf-text text-xl" />
-            <span className="text-sm font-medium">Back</span>
-          </button>
-          )}
-          {headerLeft}
-        </div>
-
-        {/* Center title - hidden when floating bar is visible */}
-        <div
-          data-slot="stack-header-center"
-          className={cn(
-            "pointer-events-auto",
-            "rounded-full px-4 py-2.5",
-            "bg-(--sf-grouped-bg-2)/80 backdrop-blur-xl",
-            "shadow-lg shadow-black/10",
-            "transition-all duration-300 ease-out",
-            showCenterTitle && title
-              ? "opacity-100 scale-100"
-              : "opacity-0 scale-95 pointer-events-none"
-          )}
-        >
-          <span className="text-sm font-semibold text-(--sf-text) whitespace-nowrap">
-            {title}
-          </span>
-        </div>
-
-        {/* Right toolbar */}
-        <div
-          data-slot="stack-header-right"
-          className={cn(
-            "pointer-events-auto flex items-center",
-            "rounded-full",
-            "bg-(--sf-grouped-bg-2)/80 backdrop-blur-xl",
-            "shadow-lg shadow-black/10",
-            "transition-all duration-300",
-            !hasRightContent && "opacity-0 scale-95 pointer-events-none"
-          )}
-        >
-          {headerRight}
-        </div>
-      </header>
-    </>
-  );
-}
-
-/* ----------------------------------------------------------------------------------
  * Standalone Floating Header (for manual use)
- * ----------------------------------------------------------------------------------*/
+ * ----------------------------------------------------------------------------------
+ * Updated to use iOS Liquid Glass styling with enhanced blur effects
+ */
 
 interface StackFloatingHeaderProps {
   /** The page title */
@@ -229,6 +91,18 @@ function StackFloatingHeader({
   const hasLeftContent = canGoBack || headerLeft;
   const hasRightContent = !!headerRight;
 
+  // Liquid glass pill styling
+  const liquidGlassStyle: React.CSSProperties = {
+    background: "color-mix(in srgb, var(--sf-grouped-bg-2) 65%, transparent)",
+    backdropFilter: "blur(40px) saturate(180%)",
+    WebkitBackdropFilter: "blur(40px) saturate(180%)",
+    boxShadow: `
+      0 0 0 0.5px color-mix(in srgb, var(--sf-border) 50%, transparent),
+      0 2px 8px -2px rgba(0, 0, 0, 0.15),
+      0 8px 24px -4px rgba(0, 0, 0, 0.12)
+    `.trim(),
+  };
+
   return (
     <>
       {/* Progressive blur backdrop */}
@@ -239,7 +113,7 @@ function StackFloatingHeader({
         data-sidebar-open={isSidebarOpen}
         className={cn(
           "pointer-events-none absolute top-4 left-0 right-0 z-20",
-          "flex items-start justify-between",
+          "flex items-start justify-between gap-2",
           "px-4",
           className
         )}
@@ -248,12 +122,11 @@ function StackFloatingHeader({
           data-slot="stack-header-left"
           className={cn(
             "pointer-events-auto flex items-center",
-            "rounded-full",
-            "bg-(--sf-grouped-bg-2)/80 backdrop-blur-xl",
-            "shadow-lg shadow-black/10",
+            "rounded-full overflow-hidden",
             "transition-all duration-300",
             !hasLeftContent && "opacity-0 scale-95 pointer-events-none"
           )}
+          style={liquidGlassStyle}
         >
           {canGoBack && !headerLeft && (
             <button
@@ -275,14 +148,13 @@ function StackFloatingHeader({
           data-slot="stack-header-center"
           className={cn(
             "pointer-events-auto",
-            "rounded-full px-4 py-2.5",
-            "bg-(--sf-grouped-bg-2)/80 backdrop-blur-xl",
-            "shadow-lg shadow-black/10",
+            "rounded-full px-4 py-2.5 overflow-hidden",
             "transition-all duration-300 ease-out",
             showCenterTitle && title
               ? "opacity-100 scale-100"
               : "opacity-0 scale-95 pointer-events-none"
           )}
+          style={liquidGlassStyle}
         >
           <span className="text-sm font-semibold text-(--sf-text) whitespace-nowrap">
             {title}
@@ -293,12 +165,11 @@ function StackFloatingHeader({
           data-slot="stack-header-right"
           className={cn(
             "pointer-events-auto flex items-center",
-            "rounded-full",
-            "bg-(--sf-grouped-bg-2)/80 backdrop-blur-xl",
-            "shadow-lg shadow-black/10",
+            "rounded-full overflow-hidden",
             "transition-all duration-300",
             !hasRightContent && "opacity-0 scale-95 pointer-events-none"
           )}
+          style={liquidGlassStyle}
         >
           {headerRight}
         </div>
@@ -309,34 +180,11 @@ function StackFloatingHeader({
 
 /* ----------------------------------------------------------------------------------
  * Header Toolbar Button
- * ----------------------------------------------------------------------------------*/
+ * ----------------------------------------------------------------------------------
+ * Re-export from Konsta header for consistency
+ */
 
-interface HeaderButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  icon?: string;
-  children?: React.ReactNode;
-}
-
-function HeaderButton({
-  icon,
-  children,
-  className,
-  ...props
-}: HeaderButtonProps) {
-  return (
-    <button
-      className={cn(
-        "flex h-10 items-center gap-1.5 rounded-full px-3",
-        "text-sf-text hover:bg-sf-fill",
-        "transition-colors",
-        className
-      )}
-      {...props}
-    >
-      {icon && <SFIcon name={icon as any} className="text-sf-text text-xl" />}
-      {children && <span className="text-sm font-medium">{children}</span>}
-    </button>
-  );
-}
+const HeaderButton = KonstaHeaderButton;
 
 /* ----------------------------------------------------------------------------------
  * Screen Wrapper with Header
@@ -410,7 +258,7 @@ function StackInner({
 }: StackProps) {
   return (
     <TabBarAwareProviderInner>
-      <WebStackHeader />
+      <KonstaStackHeader />
       <ExpoStack
         screenOptions={{
           headerShown: false,
@@ -434,7 +282,7 @@ function StackFallback({
 }: StackProps) {
   return (
     <TabBarAwareProviderFallback>
-      <WebStackHeader />
+      <KonstaStackHeader />
       <ExpoStack
         screenOptions={{
           headerShown: false,
@@ -548,6 +396,8 @@ export {
   StackFloatingHeader,
   StackScreen,
   HeaderButton,
+  KonstaStackHeader,
+  KonstaHeaderButton,
   useStackHeaderContext,
   useStackHeaderConfig,
   useCanGoBack,


### PR DESCRIPTION
- Install Konsta UI React package for iOS-style components
- Create KonstaStackHeader component using Konsta's Navbar and NavbarBackLink
- Implement liquid glass styling with enhanced blur effects (40px blur, 180% saturation)
- Add semi-transparent backgrounds with color-mix() for iOS 26+ style
- Update StackFloatingHeader with consistent liquid glass styling
- Move useCanGoBack hook to stack-context.web.tsx to avoid circular imports

https://claude.ai/code/session_014RW3MoGkiFNadxJ1gYHWzv